### PR TITLE
avoid trying to get user if there is not any yet

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -148,13 +148,18 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         if (!userManager) return;
         void (async (): Promise<void> => {
             try {
+                let initialUser: User | null;
+
                 // check if returning back from authority server
                 if (hasAuthParams() && !skipSigninCallback) {
                     const user = await userManager.signinCallback();
                     onSigninCallback && onSigninCallback(user);
+                    initialUser = user ? user : null;
+                } else {
+                    initialUser = await userManager.getUser();
                 }
-                const user = await userManager.getUser();
-                dispatch({ type: "INITIALISED", user });
+
+                dispatch({ type: "INITIALISED", user: initialUser });
             } catch (error) {
                 dispatch({ type: "ERROR", error: loginError(error) });
             }


### PR DESCRIPTION
When debugging the iframe issue (https://github.com/authts/oidc-client-ts/issues/138) i saw that we try to get an user in case of silent renew and also in case of a popup window, but at this stage we wont find any. This fix avoids that for those cases.