### PR TITLE
build: bump oidc-client-ts from 2.0.0-rc.4 to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-oidc-context",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-oidc-context",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.18.10",
@@ -36,7 +36,7 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "oidc-client-ts": "^2.0.0-rc.4",
+        "oidc-client-ts": "^2.0.0",
         "react": ">=16.8.0"
       }
     },
@@ -5503,9 +5503,9 @@
       }
     },
     "node_modules/oidc-client-ts": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.0-rc.4.tgz",
-      "integrity": "sha512-LmTjt+uXtjnBujOpZrnSdsbpN+s2c82t+t+azifJbqSqsQ9ucXDTAmp5V4Fm0JjTE19W6ZiDqGt2ns0oHIvxxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.0.tgz",
+      "integrity": "sha512-YpQVxeVXHrCmeDx1aKXcg9jtDnsbxl3ybQMmGK1PYlVpD2nqZ20IJr2YEgvaG56RPZMeCqlUrNh5keyz9uqwvg==",
       "peer": true,
       "dependencies": {
         "crypto-js": "^4.1.1",
@@ -11091,9 +11091,9 @@
       "dev": true
     },
     "oidc-client-ts": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.0-rc.4.tgz",
-      "integrity": "sha512-LmTjt+uXtjnBujOpZrnSdsbpN+s2c82t+t+azifJbqSqsQ9ucXDTAmp5V4Fm0JjTE19W6ZiDqGt2ns0oHIvxxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.0.tgz",
+      "integrity": "sha512-YpQVxeVXHrCmeDx1aKXcg9jtDnsbxl3ybQMmGK1PYlVpD2nqZ20IJr2YEgvaG56RPZMeCqlUrNh5keyz9uqwvg==",
       "peer": true,
       "requires": {
         "crypto-js": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepare": "husky install"
   },
   "peerDependencies": {
-    "oidc-client-ts": "^2.0.0-rc.4",
+    "oidc-client-ts": "^2.0.0",
     "react": ">=16.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
 Technically 2.0.0-rc.4 is same as 2.0.0

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
