### PR TITLE
@testing-library/react-hooks v8.0.0 depends on @types/react v16 …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@microsoft/api-extractor": "^7.18.10",
         "@testing-library/jest-dom": "^5.5.0",
         "@testing-library/react": "^13.1.1",
-        "@testing-library/react-hooks": "^8.0.0",
+        "@testing-library/react-hooks": "^7.0.2",
         "@types/react": "^18.0.6",
         "@types/react-dom": "^18.0.2",
         "@types/react-test-renderer": "^18.0.0",
@@ -1255,27 +1255,26 @@
       }
     },
     "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
-      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
         "react-error-boundary": "^3.1.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
         "react-dom": {
           "optional": true
         },
@@ -1414,9 +1413,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.10.tgz",
-      "integrity": "sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
+      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -5831,9 +5830,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
-      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -7979,12 +7978,15 @@
       }
     },
     "@testing-library/react-hooks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
-      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
         "react-error-boundary": "^3.1.0"
       }
     },
@@ -8115,9 +8117,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.10.tgz",
-      "integrity": "sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
+      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -11312,9 +11314,9 @@
       }
     },
     "react-error-boundary": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
-      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@microsoft/api-extractor": "^7.18.10",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^13.1.1",
-    "@testing-library/react-hooks": "^8.0.0",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/react": "^18.0.6",
     "@types/react-dom": "^18.0.2",
     "@types/react-test-renderer": "^18.0.0",


### PR DESCRIPTION
…| v17, but we have v18

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
