### PR TITLE
make sure signinCallback is only called once in React.StrictMode

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { UserManager, UserManagerSettings, User } from "oidc-client-ts";
 import type { SignoutRedirectArgs, SignoutPopupArgs } from "oidc-client-ts";
 
@@ -147,9 +147,14 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         ),
         [userManager],
     );
+    const didInitialize = useRef(false);
 
     useEffect(() => {
-        if (!userManager) return;
+        if (!userManager || didInitialize.current) {
+            return;
+        }
+        didInitialize.current = true;
+
         void (async (): Promise<void> => {
             try {
                 // check if returning back from authority server

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -2,15 +2,18 @@ import React from "react";
 
 import { AuthProvider, AuthProviderProps } from "../src/AuthProvider";
 
-export const createWrapper = (opts: AuthProviderProps) => ({
-    children,
-}: React.PropsWithChildren<AuthProviderProps>): JSX.Element => (
-    <AuthProvider
-        {...opts}
-    >
-        {children}
-    </AuthProvider>
-);
+export const createWrapper =
+    (opts: AuthProviderProps, strictMode=true) =>
+        ({ children }: React.PropsWithChildren): JSX.Element => {
+            const provider = <AuthProvider {...opts}>{children}</AuthProvider>;
+            if (!strictMode) {
+                return provider;
+            }
+
+            return (
+                <React.StrictMode>{provider}</React.StrictMode>
+            );
+        };
 
 export const createLocation = (search: string, hash: string): Location => {
     const location: Location = {


### PR DESCRIPTION
Ensure parsing the `window.location` is only done once, when using `React.StrictMode`.

~~I am not 100% sure if we need the additional guard for the event registering at all.~~
For event registering the cleanup function takes care...

Unit tests: The new test case uses `@testing-library/react`, which is the new way to test. The other test cases still use `@testing-library/react-hooks`, which should a some point be ported too. Not urgent and not in this MR. Just a technical dept (#433).

Closes/fixes #401

Fix according do documentation: https://github.com/reactwg/react-18/discussions/18

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
