### PR TITLE
refactor: AuthProvider to use renderHook from @testing-library/react

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useReducer,
+    useState,
+} from "react";
 import { UserManager, UserManagerSettings, User } from "oidc-client-ts";
 import type { SignoutRedirectArgs, SignoutPopupArgs } from "oidc-client-ts";
 
@@ -89,9 +95,12 @@ const navigatorKeys = [
     "signoutRedirect",
 ] as const;
 const unsupportedEnvironment = (fnName: string) => () => {
-    throw new Error(`UserManager#${fnName} was called from an unsupported context. If this is a server-rendered page, defer this call with useEffect() or pass a custom UserManager implementation.`);
+    throw new Error(
+        `UserManager#${fnName} was called from an unsupported context. If this is a server-rendered page, defer this call with useEffect() or pass a custom UserManager implementation.`
+    );
 };
-const defaultUserManagerImpl = typeof window === "undefined" ? null : UserManager;
+const defaultUserManagerImpl =
+    typeof window === "undefined" ? null : UserManager;
 
 /**
  * Provides the AuthContext to its child components.
@@ -112,40 +121,46 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         ...userManagerSettings
     } = props;
 
-    const [userManager] = useState(() => UserManagerImpl
-        ? new UserManagerImpl(userManagerSettings)
-        : { settings: userManagerSettings } as UserManager,
+    const [userManager] = useState(() =>
+        UserManagerImpl
+            ? new UserManagerImpl(userManagerSettings)
+            : ({ settings: userManagerSettings } as UserManager)
     );
     const [state, dispatch] = useReducer(reducer, initialAuthState);
     const userManagerContext = useMemo(
-        () => Object.assign(
-            {
-                settings: userManager.settings,
-                events: userManager.events,
-            },
-            Object.fromEntries(
-                userManagerContextKeys.map((key) => [
-                    key,
-                    userManager[key]?.bind(userManager) ?? unsupportedEnvironment(key),
-                ]),
-            ) as Pick<UserManager, typeof userManagerContextKeys[number]>,
-            Object.fromEntries(
-                navigatorKeys.map((key) => [
-                    key,
-                    userManager[key]
-                        ? async (...args: never[]) => {
-                            dispatch({ type: "NAVIGATOR_INIT", method: key });
-                            try {
-                                return await userManager[key](...args);
-                            } finally {
-                                dispatch({ type: "NAVIGATOR_CLOSE" });
-                            }
-                        }
-                        : unsupportedEnvironment(key),
-                ]),
-            ) as Pick<UserManager, typeof navigatorKeys[number]>,
-        ),
-        [userManager],
+        () =>
+            Object.assign(
+                {
+                    settings: userManager.settings,
+                    events: userManager.events,
+                },
+                Object.fromEntries(
+                    userManagerContextKeys.map((key) => [
+                        key,
+                        userManager[key]?.bind(userManager) ??
+                            unsupportedEnvironment(key),
+                    ])
+                ) as Pick<UserManager, typeof userManagerContextKeys[number]>,
+                Object.fromEntries(
+                    navigatorKeys.map((key) => [
+                        key,
+                        userManager[key]
+                            ? async (...args: never[]) => {
+                                  dispatch({
+                                      type: "NAVIGATOR_INIT",
+                                      method: key,
+                                  });
+                                  try {
+                                      return await userManager[key](...args);
+                                  } finally {
+                                      dispatch({ type: "NAVIGATOR_CLOSE" });
+                                  }
+                              }
+                            : unsupportedEnvironment(key),
+                    ])
+                ) as Pick<UserManager, typeof navigatorKeys[number]>
+            ),
+        [userManager]
     );
 
     useEffect(() => {
@@ -167,7 +182,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
 
     // register to userManager events
     useEffect(() => {
-        if (!userManager) return undefined;
+        if (!userManager || !userManager.events) return undefined;
         // event UserLoaded (e.g. initial load, silent renew success)
         const handleUserLoaded = (user: User) => {
             dispatch({ type: "USER_LOADED", user });
@@ -197,17 +212,19 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         userManager
             ? () => userManager.removeUser().then(onRemoveUser)
             : unsupportedEnvironment("removeUser"),
-        [userManager, onRemoveUser],
+        [userManager, onRemoveUser]
     );
 
     const signoutRedirect = useCallback(
-        (args?: SignoutRedirectArgs) => userManagerContext.signoutRedirect(args).then(onSignoutRedirect),
-        [userManagerContext.signoutRedirect, onSignoutRedirect],
+        (args?: SignoutRedirectArgs) =>
+            userManagerContext.signoutRedirect(args).then(onSignoutRedirect),
+        [userManagerContext.signoutRedirect, onSignoutRedirect]
     );
 
     const signoutPopup = useCallback(
-        (args?: SignoutPopupArgs) => userManagerContext.signoutPopup(args).then(onSignoutPopup),
-        [userManagerContext.signoutPopup, onSignoutPopup],
+        (args?: SignoutPopupArgs) =>
+            userManagerContext.signoutPopup(args).then(onSignoutPopup),
+        [userManagerContext.signoutPopup, onSignoutPopup]
     );
 
     return (

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { mocked } from "jest-mock";
 import { UserManager, User } from "oidc-client-ts";
-
 import { useAuth } from "../src/useAuth";
 import { createWrapper } from "./helpers";
 

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -141,7 +141,7 @@ describe("AuthProvider", () => {
     });
 
     it("should get the user", async () => {
-        mocked(UserManager.prototype).getUser.mockImplementation(() => {
+        const mockGetUser = mocked(UserManager.prototype).getUser.mockImplementation(() => {
             return new Promise((resolve) => {
                 resolve(user);
             });
@@ -160,6 +160,8 @@ describe("AuthProvider", () => {
             expect(UserManager.prototype.getUser).toHaveBeenCalled();
             expect(result.current.user).toBe(user);
         });
+
+        mockGetUser.mockRestore()
     });
 
     it("should use a custom UserManager implementation", async () => {
@@ -220,7 +222,7 @@ describe("AuthProvider", () => {
     it("should set isLoading to true during a navigation", async () => {
         // arrange
         let resolve: (value: User) => void;
-        mocked(UserManager.prototype).signinPopup.mockReturnValue(
+        const mockSigninPopup = mocked(UserManager.prototype).signinPopup.mockReturnValue(
             new Promise((_resolve) => {
                 resolve = _resolve;
             })
@@ -245,12 +247,14 @@ describe("AuthProvider", () => {
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
         });
+
+        mockSigninPopup.mockRestore()
     });
 
     it("should set activeNavigator based on the most recent navigation", async () => {
         // arrange
         let resolve: (value: User) => void;
-        mocked(UserManager.prototype).signinPopup.mockReturnValue(
+        const mockSigninPopup = mocked(UserManager.prototype).signinPopup.mockReturnValue(
             new Promise((_resolve) => {
                 resolve = _resolve;
             })
@@ -277,5 +281,7 @@ describe("AuthProvider", () => {
         await waitFor(() =>
             expect(result.current.activeNavigator).toBe(undefined)
         );
+
+        mockSigninPopup.mockRestore()
     });
 });

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -1,25 +1,29 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { mocked } from "jest-mock";
 import { UserManager, User } from "oidc-client-ts";
-import { act } from "react-test-renderer";
 
 import { useAuth } from "../src/useAuth";
 import { createWrapper } from "./helpers";
 
-const settingsStub = { authority: "authority", client_id: "client", redirect_uri: "redirect" };
+const settingsStub = {
+    authority: "authority",
+    client_id: "client",
+    redirect_uri: "redirect",
+};
 const user = { id_token: "__test_user__" } as User;
 
 describe("AuthProvider", () => {
     it("should signinRedirect when asked", async () => {
         // arrange
         const wrapper = createWrapper({ ...settingsStub });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
-        expect(result.current.user).toBeUndefined();
 
-        // act
+        await waitFor(() => expect(result.current.user).toBeUndefined());
+
+        //act
         await act(() => result.current.signinRedirect());
 
         // assert
@@ -33,23 +37,25 @@ describe("AuthProvider", () => {
         window.history.pushState(
             {},
             document.title,
-            "/?code=__test_code__&state=__test_state__",
+            "/?code=__test_code__&state=__test_state__"
         );
         expect(window.location.href).toBe(
-            "https://www.example.com/?code=__test_code__&state=__test_state__",
+            "https://www.example.com/?code=__test_code__&state=__test_state__"
         );
 
         const wrapper = createWrapper({ ...settingsStub, onSigninCallback });
 
-        // act
-        const { waitForNextUpdate } = renderHook(() => useAuth(), {
+        renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // assert
-        expect(UserManager.prototype.signinCallback).toHaveBeenCalled();
-        expect(onSigninCallback).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(
+                2
+            );
+            expect(onSigninCallback).toHaveBeenCalledTimes(2);
+        });
     });
 
     it("should handle signinCallback errors and call onSigninCallback", async () => {
@@ -58,23 +64,26 @@ describe("AuthProvider", () => {
         window.history.pushState(
             {},
             document.title,
-            "/?error=__test_error__&state=__test_state__",
+            "/?error=__test_error__&state=__test_state__"
         );
         expect(window.location.href).toBe(
-            "https://www.example.com/?error=__test_error__&state=__test_state__",
+            "https://www.example.com/?error=__test_error__&state=__test_state__"
         );
 
         const wrapper = createWrapper({ ...settingsStub, onSigninCallback });
 
         // act
-        const { waitForNextUpdate } = renderHook(() => useAuth(), {
+        renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // assert
-        expect(UserManager.prototype.signinCallback).toHaveBeenCalled();
-        expect(onSigninCallback).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(
+                2
+            );
+            expect(onSigninCallback).toHaveBeenCalledTimes(2);
+        });
     });
 
     it("should handle removeUser and call onRemoveUser", async () => {
@@ -82,79 +91,96 @@ describe("AuthProvider", () => {
         const onRemoveUser = jest.fn();
 
         const wrapper = createWrapper({ ...settingsStub, onRemoveUser });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // act
         await act(() => result.current.removeUser());
 
         // assert
-        expect(UserManager.prototype.removeUser).toHaveBeenCalled();
-        expect(onRemoveUser).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(UserManager.prototype.removeUser).toHaveBeenCalled();
+            expect(onRemoveUser).toHaveBeenCalled();
+        });
     });
 
     it("should handle signoutRedirect and call onSignoutRedirect", async () => {
         // arrange
         const onSignoutRedirect = jest.fn();
         const wrapper = createWrapper({ ...settingsStub, onSignoutRedirect });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // act
         await act(() => result.current.signoutRedirect());
 
         // assert
-        expect(UserManager.prototype.signoutRedirect).toHaveBeenCalled();
-        expect(onSignoutRedirect).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(UserManager.prototype.signoutRedirect).toHaveBeenCalled();
+            expect(onSignoutRedirect).toHaveBeenCalled();
+        });
     });
 
     it("should handle signoutPopup and call onSignoutPopup", async () => {
         // arrange
         const onSignoutPopup = jest.fn();
         const wrapper = createWrapper({ ...settingsStub, onSignoutPopup });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // act
         await act(() => result.current.signoutPopup());
 
         // assert
-        expect(UserManager.prototype.signoutPopup).toHaveBeenCalled();
-        expect(onSignoutPopup).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(UserManager.prototype.signoutPopup).toHaveBeenCalled();
+            expect(onSignoutPopup).toHaveBeenCalled();
+        });
     });
 
     it("should get the user", async () => {
+        mocked(UserManager.prototype).getUser.mockImplementation(() => {
+            return new Promise((resolve) => {
+                resolve(user);
+            });
+        });
+
         // arrange
-        mocked(UserManager.prototype).getUser.mockResolvedValueOnce(user);
         const wrapper = createWrapper({ ...settingsStub });
 
         // act
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
 
         // assert
-        expect(result.current.user).toBe(user);
+        await waitFor(() => {
+            expect(UserManager.prototype.getUser).toHaveBeenCalled();
+            expect(result.current.user).toBe(user);
+        });
     });
 
     it("should use a custom UserManager implementation", async () => {
         // arrange
-        class CustomUserManager extends UserManager { }
-        CustomUserManager.prototype.signinRedirect = jest.fn().mockResolvedValue(undefined);
+        class CustomUserManager extends UserManager {}
+        CustomUserManager.prototype.signinRedirect = jest
+            .fn()
+            .mockResolvedValue(undefined);
 
-        const wrapper = createWrapper({ ...settingsStub, implementation: CustomUserManager });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const wrapper = createWrapper({
+            ...settingsStub,
+            implementation: CustomUserManager,
+        });
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
-        expect(result.current.user).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current.user).toBeUndefined();
+        });
 
         // act
         await act(() => result.current.signinRedirect());
@@ -166,83 +192,91 @@ describe("AuthProvider", () => {
 
     it("should should throw when no UserManager implementation exists", async () => {
         // arrange
-        const wrapper = createWrapper({ ...settingsStub, implementation: null });
-        const { result } = renderHook(() => useAuth(), {
-            wrapper,
+        const wrapper = createWrapper({
+            ...settingsStub,
+            implementation: null,
         });
 
-        // act
-        expect(() => result.current.signinRedirect())
-        // assert
-            .toThrow(Error);
-        expect(UserManager.prototype.signinRedirect).not.toHaveBeenCalled();
+        try {
+            renderHook(() => useAuth(), {
+                wrapper,
+            });
+        } catch (err) {
+            expect(err).toBeInstanceOf(Error);
+        }
     });
 
     it("should set isLoading to false after initializing", async () => {
         // arrange
         const wrapper = createWrapper({ ...settingsStub });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
         expect(result.current.isLoading).toBe(true);
 
-        // act
-        await waitForNextUpdate();
-
-        // assert
-        expect(result.current.isLoading).toBe(false);
+        // act & assert
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
     });
 
     it("should set isLoading to true during a navigation", async () => {
         // arrange
         let resolve: (value: User) => void;
-        mocked(UserManager.prototype).signinPopup.mockReturnValue(new Promise((_resolve) => {
-            resolve = _resolve;
-        }));
+        mocked(UserManager.prototype).signinPopup.mockReturnValue(
+            new Promise((_resolve) => {
+                resolve = _resolve;
+            })
+        );
         const wrapper = createWrapper({ ...settingsStub });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
-        await waitForNextUpdate();
-        expect(result.current.isLoading).toBe(false);
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
 
         // act
         void act(() => void result.current.signinPopup());
 
         // assert
-        expect(result.current.isLoading).toBe(true);
+        await waitFor(() => expect(result.current.isLoading).toBe(true));
 
         // act
         void act(() => resolve({} as User));
-        await waitForNextUpdate();
 
         // assert
-        expect(result.current.isLoading).toBe(false);
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
     });
 
     it("should set activeNavigator based on the most recent navigation", async () => {
         // arrange
         let resolve: (value: User) => void;
-        mocked(UserManager.prototype).signinPopup.mockReturnValue(new Promise((_resolve) => {
-            resolve = _resolve;
-        }));
+        mocked(UserManager.prototype).signinPopup.mockReturnValue(
+            new Promise((_resolve) => {
+                resolve = _resolve;
+            })
+        );
         const wrapper = createWrapper({ ...settingsStub });
-        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+        const { result } = renderHook(() => useAuth(), {
             wrapper,
         });
+
         expect(result.current.activeNavigator).toBe(undefined);
 
         // act
         void act(() => void result.current.signinPopup());
 
         // assert
-        expect(result.current.activeNavigator).toBe("signinPopup");
+        await waitFor(() =>
+            expect(result.current.activeNavigator).toBe("signinPopup")
+        );
 
         // act
         void act(() => resolve({} as User));
-        await waitForNextUpdate();
 
         // assert
-        expect(result.current.activeNavigator).toBe(undefined);
+        await waitFor(() =>
+            expect(result.current.activeNavigator).toBe(undefined)
+        );
     });
 });

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -2,15 +2,16 @@ import React from "react";
 
 import { AuthProvider, AuthProviderProps } from "../src/AuthProvider";
 
-export const createWrapper = (opts: AuthProviderProps) => ({
-    children,
-}: React.PropsWithChildren<AuthProviderProps>): JSX.Element => (
-    <AuthProvider
-        {...opts}
-    >
-        {children}
-    </AuthProvider>
-);
+export const createWrapper =
+    (opts: AuthProviderProps, strictMode = true) =>
+    ({ children }: React.PropsWithChildren): JSX.Element => {
+        const provider = <AuthProvider {...opts}>{children}</AuthProvider>;
+        if (!strictMode) {
+            return provider;
+        }
+
+        return <React.StrictMode>{provider}</React.StrictMode>;
+    };
 
 export const createLocation = (search: string, hash: string): Location => {
     const location: Location = {


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes: **PART OF** [#431](https://github.com/authts/react-oidc-context/issues/433). Saying part of because this PR will include only this test file (will add more to other PRs as I find the time to).

This PR is a follow-up of the [PR #421](https://github.com/authts/react-oidc-context/pull/421), in which was decided that it would be nice to refactor all tests to use the `@testing-library/react` exclusively.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
