### PR TITLE
refactor: useAuth tests to use renderHook from @testing-library/react

### DIFF
--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -2,15 +2,16 @@ import React from "react";
 
 import { AuthProvider, AuthProviderProps } from "../src/AuthProvider";
 
-export const createWrapper = (opts: AuthProviderProps) => ({
-    children,
-}: React.PropsWithChildren<AuthProviderProps>): JSX.Element => (
-    <AuthProvider
-        {...opts}
-    >
-        {children}
-    </AuthProvider>
-);
+export const createWrapper =
+    (opts: AuthProviderProps, strictMode = true) =>
+    ({ children }: React.PropsWithChildren): JSX.Element => {
+        const provider = <AuthProvider {...opts}>{children}</AuthProvider>;
+        if (!strictMode) {
+            return provider;
+        }
+
+        return <React.StrictMode>{provider}</React.StrictMode>;
+    };
 
 export const createLocation = (search: string, hash: string): Location => {
     const location: Location = {

--- a/test/useAuth.test.tsx
+++ b/test/useAuth.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { mocked } from "jest-mock";
 import { useAuth } from "../src/useAuth";
 import { createWrapper } from "./helpers";
 
@@ -19,10 +20,12 @@ describe("useAuth", () => {
     });
 
     it("should throw with no provider", async () => {
+        // We want to show the error message on the screen since we already are doing an assert for it
+        mocked(global.console).error.mockImplementation(() => {});
+
         // act
         try {
-            const { result } = renderHook(() => useAuth());
-            fail("should not come here");
+            renderHook(() => useAuth());
         } catch (err) {
             //assert
             expect(err).toBeInstanceOf(Error);

--- a/test/useAuth.test.tsx
+++ b/test/useAuth.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
-import { mocked } from "jest-mock";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useAuth } from "../src/useAuth";
 import { createWrapper } from "./helpers";
 
@@ -20,9 +19,6 @@ describe("useAuth", () => {
     });
 
     it("should throw with no provider", async () => {
-        // We want to show the error message on the screen since we already are doing an assert for it
-        mocked(global.console).error.mockImplementation(() => {});
-
         // act
         try {
             renderHook(() => useAuth());

--- a/test/useAuth.test.tsx
+++ b/test/useAuth.test.tsx
@@ -1,32 +1,34 @@
-import { renderHook } from "@testing-library/react-hooks";
-
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { useAuth } from "../src/useAuth";
 import { createWrapper } from "./helpers";
 
-const settingsStub = { authority: "authority", client_id: "client", redirect_uri: "redirect" };
+const settingsStub = {
+    authority: "authority",
+    client_id: "client",
+    redirect_uri: "redirect",
+};
 
 describe("useAuth", () => {
     it("should provide the auth context", async () => {
         // arrange
         const wrapper = createWrapper({ ...settingsStub });
-        const { result, waitForNextUpdate } = renderHook(useAuth, { wrapper });
-        await waitForNextUpdate();
+        const { result } = renderHook(() => useAuth(), { wrapper });
 
         // assert
-        expect(result.current).toBeDefined();
+        await waitFor(() => expect(result.current).toBeDefined());
     });
 
     it("should throw with no provider", async () => {
-        const { result } = renderHook(useAuth);
-
         // act
         try {
-            await result.current.signinRedirect();
+            const { result } = renderHook(() => useAuth());
             fail("should not come here");
-        }
-        catch (err) {
+        } catch (err) {
+            //assert
             expect(err).toBeInstanceOf(Error);
-            expect((err as Error).message).toContain("AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component.");
+            expect((err as Error).message).toContain(
+                "AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component."
+            );
         }
     });
 });


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes: **PART OF** [#431](https://github.com/authts/react-oidc-context/issues/433).

This PR is a follow-up of the [PR #421](https://github.com/authts/react-oidc-context/pull/421), in which was decided that it would be nice to refactor all tests to use the `@testing-library/react` exclusively.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
