### PR TITLE
AuthProviderUserManagerProps must not contain anything from UserManagerSettings

### DIFF
--- a/docs/react-oidc-context.api.md
+++ b/docs/react-oidc-context.api.md
@@ -60,19 +60,8 @@ export interface AuthContextProps extends AuthState {
 export const AuthProvider: (props: AuthProviderProps) => JSX.Element;
 
 // @public (undocumented)
-export interface AuthProviderNoUserManagerProps extends AuthProviderPropsBase {
-    // (undocumented)
-    userManager?: never;
-}
-
-// @public (undocumented)
-export type AuthProviderProps = AuthProviderNoUserManagerProps | AuthProviderUserManagerProps;
-
-// @public (undocumented)
-export interface AuthProviderPropsBase extends UserManagerSettings {
+export interface AuthProviderBaseProps {
     children?: React_2.ReactNode;
-    // @deprecated (undocumented)
-    implementation?: typeof UserManager | null;
     onRemoveUser?: () => Promise<void> | void;
     onSigninCallback?: (user: User | void) => Promise<void> | void;
     // @deprecated (undocumented)
@@ -80,17 +69,22 @@ export interface AuthProviderPropsBase extends UserManagerSettings {
     // @deprecated (undocumented)
     onSignoutRedirect?: () => Promise<void> | void;
     skipSigninCallback?: boolean;
-    userManager?: UserManager;
+}
+
+// @public
+export interface AuthProviderNoUserManagerProps extends AuthProviderBaseProps, UserManagerSettings {
+    // @deprecated (undocumented)
+    implementation?: typeof UserManager | null;
+    userManager?: never;
 }
 
 // @public (undocumented)
-export interface AuthProviderUserManagerProps extends Omit<AuthProviderPropsBase, "redirect_uri" | "client_id" | "authority"> {
-    // (undocumented)
-    authority?: never;
-    // (undocumented)
-    client_id?: never;
-    // (undocumented)
-    redirect_uri?: never;
+export type AuthProviderProps = AuthProviderNoUserManagerProps | AuthProviderUserManagerProps;
+
+// @public
+export interface AuthProviderUserManagerProps extends AuthProviderBaseProps {
+    implementation?: never;
+    userManager?: UserManager;
 }
 
 // @public

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -22,7 +22,7 @@ import { hasAuthParams, loginError } from "./utils";
 /**
  * @public
  */
-export interface AuthProviderPropsBase extends UserManagerSettings {
+export interface AuthProviderBaseProps {
     /**
      * The child nodes your Provider has wrapped
      */
@@ -79,32 +79,42 @@ export interface AuthProviderPropsBase extends UserManagerSettings {
      * @deprecated On sign out popup hook. Can be a async function.
      */
     onSignoutPopup?: () => Promise<void> | void;
+}
 
-    /**
-     * Allow passing a custom UserManager.
-     */
-    userManager?: UserManager;
-
+/**
+ * This interface (default) is used to pass `UserManagerSettings` together with `AuthProvider` properties to the provider.
+ *
+ * @public
+ */
+export interface AuthProviderNoUserManagerProps extends AuthProviderBaseProps, UserManagerSettings
+{
     /**
      * @deprecated Allow passing a custom UserManager implementation
      */
     implementation?: typeof UserManager | null;
-}
 
-/**
- * @public
- */
-export interface AuthProviderUserManagerProps extends Omit<AuthProviderPropsBase, "redirect_uri" | "client_id" | "authority"> {
-    redirect_uri?: never;
-    client_id?: never;
-    authority?: never;
-}
-
-/**
- * @public
- */
-export interface AuthProviderNoUserManagerProps extends AuthProviderPropsBase {
+    /**
+     * Prevent this property.
+     */
     userManager?: never;
+}
+
+/**
+ * This interface is used to pass directly a `UserManager` instance together with `AuthProvider` properties to the provider.
+ *
+ * @public
+ */
+export interface AuthProviderUserManagerProps extends AuthProviderBaseProps
+{
+    /**
+     * Allow passing a custom UserManager instance.
+     */
+    userManager?: UserManager;
+
+    /**
+     * Prevent this property.
+     */
+    implementation?: never;
 }
 
 /**
@@ -138,6 +148,7 @@ const defaultUserManagerImpl =
 
 /**
  * Provides the AuthContext to its child components.
+ *
  * @public
  */
 export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
@@ -152,7 +163,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         onSignoutPopup,
 
         implementation: UserManagerImpl = defaultUserManagerImpl,
-        userManager: userManagerProp,
+        userManager: userManagerProp = null,
         ...userManagerSettings
     } = props;
 


### PR DESCRIPTION
Follow up of #466, which only covered some properties of `UserManagerSettings`. Where this MR splits `AuthProviderNoUserManagerProps` and AuthProviderUserManagerProps for all relevant properties. #466 was type-wise a breaking change, thus the next release will bump to 3.0.0.

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
