### PR TITLE
fix error when user.state is set to undefined.

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -201,16 +201,14 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         didInitialize.current = true;
 
         void (async (): Promise<void> => {
+            let user: User | void | null = null;
             try {
-                let user = await userManager.getUser();
                 // check if returning back from authority server
                 if (hasAuthParams() && !skipSigninCallback) {
-                    const userCallback = await userManager.signinCallback();
-                    onSigninCallback && onSigninCallback(userCallback);
-                    if (userCallback) {
-                        user = userCallback; //preserve user.state in INITIALISED event, in case it becomes undefined
-                    }
+                    user = await userManager.signinCallback();
+                    onSigninCallback && onSigninCallback(user);
                 }
+                user = !user ? await userManager.getUser() : user;
                 dispatch({ type: "INITIALISED", user });
             } catch (error) {
                 dispatch({ type: "ERROR", error: loginError(error) });

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -208,7 +208,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
                     const userCallback = await userManager.signinCallback();
                     onSigninCallback && onSigninCallback(userCallback);
                     if (userCallback) {
-                        user = userCallback;
+                        user = userCallback; //preserve user.state in INITIALISED event, in case it becomes undefined
                     }
                 }
                 dispatch({ type: "INITIALISED", user });

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -202,12 +202,15 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
 
         void (async (): Promise<void> => {
             try {
+                let user = await userManager.getUser();
                 // check if returning back from authority server
                 if (hasAuthParams() && !skipSigninCallback) {
-                    const user = await userManager.signinCallback();
-                    onSigninCallback && onSigninCallback(user);
+                    const userCallback = await userManager.signinCallback();
+                    onSigninCallback && onSigninCallback(userCallback);
+                    if (userCallback) {
+                        user = userCallback;
+                    }
                 }
-                const user = await userManager.getUser();
                 dispatch({ type: "INITIALISED", user });
             } catch (error) {
                 dispatch({ type: "ERROR", error: loginError(error) });

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -49,7 +49,7 @@ describe("AuthProvider", () => {
         });
 
         // assert
-        expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1));
         await waitFor(() => expect(onSigninCallback).toHaveBeenCalledTimes(1));
     });
 
@@ -101,7 +101,7 @@ describe("AuthProvider", () => {
         });
 
         // assert
-        expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1));
         await waitFor(() => expect(onSigninCallback).toHaveBeenCalledTimes(1));
     });
 

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -49,7 +49,7 @@ describe("AuthProvider", () => {
         });
 
         // assert
-        await waitFor(() => expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1));
+        expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1);
         await waitFor(() => expect(onSigninCallback).toHaveBeenCalledTimes(1));
     });
 
@@ -101,7 +101,7 @@ describe("AuthProvider", () => {
         });
 
         // assert
-        await waitFor(() => expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1));
+        expect(UserManager.prototype.signinCallback).toHaveBeenCalledTimes(1);
         await waitFor(() => expect(onSigninCallback).toHaveBeenCalledTimes(1));
     });
 


### PR DESCRIPTION
USER_LOADED event sets the right user.state, but INITIALISED event will reset user.state  to undefined, use signinCallback user to set state to solve the issue

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
