### PR TITLE
useAuth should not throw

### DIFF
--- a/src/useAuth.ts
+++ b/src/useAuth.ts
@@ -9,8 +9,8 @@ export const useAuth = (): AuthContextProps => {
     const context = React.useContext(AuthContext);
 
     if (!context) {
-        throw new Error("AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component.");
+        console.warn("AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component.");
     }
 
-    return context;
+    return context as AuthContextProps;
 };

--- a/test/useAuth.test.tsx
+++ b/test/useAuth.test.tsx
@@ -18,16 +18,8 @@ describe("useAuth", () => {
         await waitFor(() => expect(result.current).toBeDefined());
     });
 
-    it("should throw with no provider", async () => {
-        // act
-        try {
-            renderHook(() => useAuth());
-        } catch (err) {
-            //assert
-            expect(err).toBeInstanceOf(Error);
-            expect((err as Error).message).toContain(
-                "AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component.",
-            );
-        }
+    it("should return undefined with no provider", async () => {
+        const { result } = renderHook(() => useAuth());
+        expect(result.current).toBeUndefined();
     });
 });


### PR DESCRIPTION
resolves #855

instead of letting useAuth throw if there is no provider, allow to not wrap the parent(s) with the provider, to make the oauth config dynamic and allow it to lazy load later. in consumer code, just check that the value of useAuth is not undefined.

this allows an app to have different oauth configs depending on the runtime without having to "remove" all useAuth usages if there is no provider yet.

fyi it seems the old test for checking the exception was not working (no fail after removing the exception).

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
