### PR TITLE
feat: add signinResourceOwnerCredentials

### DIFF
--- a/docs/react-oidc-context.api.md
+++ b/docs/react-oidc-context.api.md
@@ -10,6 +10,7 @@ import type { RevokeTokensTypes } from 'oidc-client-ts';
 import type { SessionStatus } from 'oidc-client-ts';
 import type { SigninPopupArgs } from 'oidc-client-ts';
 import type { SigninRedirectArgs } from 'oidc-client-ts';
+import type { SigninResourceOwnerCredentialsArgs } from 'oidc-client-ts';
 import type { SigninSilentArgs } from 'oidc-client-ts';
 import type { SignoutPopupArgs } from 'oidc-client-ts';
 import type { SignoutRedirectArgs } from 'oidc-client-ts';
@@ -39,6 +40,8 @@ export interface AuthContextProps extends AuthState {
     signinPopup(args?: SigninPopupArgs): Promise<User>;
     // (undocumented)
     signinRedirect(args?: SigninRedirectArgs): Promise<void>;
+    // (undocumented)
+    signinResourceOwnerCredentials(args: SigninResourceOwnerCredentialsArgs): Promise<User>;
     // (undocumented)
     signinSilent(args?: SigninSilentArgs): Promise<User | null>;
     // (undocumented)
@@ -92,7 +95,7 @@ export interface AuthProviderUserManagerProps extends Omit<AuthProviderPropsBase
 
 // @public
 export interface AuthState {
-    activeNavigator?: "signinRedirect" | "signinPopup" | "signinSilent" | "signoutRedirect" | "signoutPopup" | "signoutSilent";
+    activeNavigator?: "signinRedirect" | "signinResourceOwnerCredentials" | "signinPopup" | "signinSilent" | "signoutRedirect" | "signoutPopup" | "signoutSilent";
     error?: Error;
     isAuthenticated: boolean;
     isLoading: boolean;

--- a/src/AuthContext.ts
+++ b/src/AuthContext.ts
@@ -3,7 +3,7 @@ import type {
     UserManagerSettings, UserManagerEvents, User, SessionStatus,
     SigninPopupArgs, SigninSilentArgs, SigninRedirectArgs,
     SignoutRedirectArgs, SignoutPopupArgs, QuerySessionStatusArgs,
-    RevokeTokensTypes, SignoutSilentArgs,
+    RevokeTokensTypes, SignoutSilentArgs, SigninResourceOwnerCredentialsArgs,
 } from "oidc-client-ts";
 
 import type { AuthState } from "./AuthState";
@@ -22,6 +22,7 @@ export interface AuthContextProps extends AuthState {
     signinPopup(args?: SigninPopupArgs): Promise<User>;
     signinSilent(args?: SigninSilentArgs): Promise<User | null>;
     signinRedirect(args?: SigninRedirectArgs): Promise<void>;
+    signinResourceOwnerCredentials(args: SigninResourceOwnerCredentialsArgs): Promise<User>;
     signoutRedirect(args?: SignoutRedirectArgs): Promise<void>;
     signoutPopup(args?: SignoutPopupArgs): Promise<void>;
     signoutSilent(args?: SignoutSilentArgs): Promise<void>;

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -11,6 +11,12 @@ import type {
     SignoutRedirectArgs,
     SignoutPopupArgs,
     SignoutSilentArgs,
+    ExtraSigninRequestArgs,
+    ExtraSignoutRequestArgs,
+    IFrameWindowParams,
+    PopupWindowParams,
+    ProcessResourceOwnerPasswordCredentialsArgs,
+    RedirectParams,
 } from "oidc-client-ts";
 
 import { AuthContext } from "./AuthContext";
@@ -122,6 +128,7 @@ const navigatorKeys = [
     "signinPopup",
     "signinSilent",
     "signinRedirect",
+    "signinResourceOwnerCredentials",
     "signoutPopup",
     "signoutRedirect",
     "signoutSilent",
@@ -133,6 +140,14 @@ const unsupportedEnvironment = (fnName: string) => () => {
 };
 const defaultUserManagerImpl =
     typeof window === "undefined" ? null : UserManager;
+
+type NavigatorArgTypes =
+    ExtraSigninRequestArgs &
+    ExtraSignoutRequestArgs &
+    IFrameWindowParams &
+    PopupWindowParams &
+    ProcessResourceOwnerPasswordCredentialsArgs &
+    RedirectParams;
 
 /**
  * Provides the AuthContext to its child components.
@@ -180,13 +195,13 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
                     navigatorKeys.map((key) => [
                         key,
                         userManager[key]
-                            ? async (...args: never[]) => {
+                            ? async (args: NavigatorArgTypes) => {
                                 dispatch({
                                     type: "NAVIGATOR_INIT",
                                     method: key,
                                 });
                                 try {
-                                    return await userManager[key](...args);
+                                    return await userManager[key](args);
                                 } catch (error) {
                                     dispatch({ type: "ERROR", error: error as Error });
                                     return null;

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -11,12 +11,7 @@ import type {
     SignoutRedirectArgs,
     SignoutPopupArgs,
     SignoutSilentArgs,
-    ExtraSigninRequestArgs,
-    ExtraSignoutRequestArgs,
-    IFrameWindowParams,
-    PopupWindowParams,
     ProcessResourceOwnerPasswordCredentialsArgs,
-    RedirectParams,
 } from "oidc-client-ts";
 
 import { AuthContext } from "./AuthContext";
@@ -141,14 +136,6 @@ const unsupportedEnvironment = (fnName: string) => () => {
 const defaultUserManagerImpl =
     typeof window === "undefined" ? null : UserManager;
 
-type NavigatorArgTypes =
-    ExtraSigninRequestArgs &
-    ExtraSignoutRequestArgs &
-    IFrameWindowParams &
-    PopupWindowParams &
-    ProcessResourceOwnerPasswordCredentialsArgs &
-    RedirectParams;
-
 /**
  * Provides the AuthContext to its child components.
  * @public
@@ -195,7 +182,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
                     navigatorKeys.map((key) => [
                         key,
                         userManager[key]
-                            ? async (args: NavigatorArgTypes) => {
+                            ? async (args: ProcessResourceOwnerPasswordCredentialsArgs & never[]) => {
                                 dispatch({
                                     type: "NAVIGATOR_INIT",
                                     method: key,

--- a/src/AuthState.ts
+++ b/src/AuthState.ts
@@ -24,7 +24,7 @@ export interface AuthState {
     /**
      * Tracks the status of most recent signin/signout request method.
      */
-    activeNavigator?: "signinRedirect" | "signinPopup" | "signinSilent" | "signoutRedirect" | "signoutPopup" | "signoutSilent";
+    activeNavigator?: "signinRedirect" | "signinResourceOwnerCredentials" | "signinPopup" | "signinSilent" | "signoutRedirect" | "signoutPopup" | "signoutSilent";
 
     /**
      * Was there a signin or silent renew error?

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -105,6 +105,28 @@ describe("AuthProvider", () => {
         await waitFor(() => expect(onSigninCallback).toHaveBeenCalledTimes(1));
     });
 
+    it("should signinResourceOwnerCredentials when asked", async () => {
+        // arrange
+        const wrapper = createWrapper({ ...settingsStub });
+
+        const { result } = renderHook(() => useAuth(), {
+            wrapper,
+        });
+
+        await waitFor(() => expect(result.current.user).toBeUndefined());
+
+        //act
+        await act(() => result.current.signinResourceOwnerCredentials({
+            username: "username",
+            password: "password",
+            skipUserInfo: false,
+        }));
+
+        // assert
+        expect(UserManager.prototype.signinResourceOwnerCredentials).toHaveBeenCalled();
+        expect(UserManager.prototype.getUser).toHaveBeenCalled();
+    });
+
     it("should handle removeUser and call onRemoveUser", async () => {
         // arrange
         const onRemoveUser = jest.fn();

--- a/test/__mocks__/oidc-client-ts.ts
+++ b/test/__mocks__/oidc-client-ts.ts
@@ -36,6 +36,7 @@ MockUserManager.prototype.signinSilent = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signinSilentCallback = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signinRedirect = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signinRedirectCallback = jest.fn().mockResolvedValue(undefined);
+MockUserManager.prototype.signinResourceOwnerCredentials = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signoutRedirect = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signoutRedirectCallback = jest.fn().mockResolvedValue(undefined);
 MockUserManager.prototype.signoutPopup = jest.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
I added the signinResourceOwnerCredentials method in AuthContextProps for [Resource Owner Password Credentials Grant]() in OAuth2.0.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
