### PR TITLE
doc(readme): Fix broken link for LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,5 +304,5 @@ which lacks error handling and
 ## License
 
 This project is licensed under the MIT license. See the
-[LICENSE](https://github.com/authts/oidc-client-react/blob/main/LICENSE) file
+[LICENSE](https://github.com/authts/react-oidc-context/blob/main/LICENSE) file
 for more info.


### PR DESCRIPTION
I fixed the broken link for LICENSE in README.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
