### PR TITLE
fix(build): generate esm package.json with version

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 const { buildSync } = require("esbuild");
 const { join } = require("path");
+const fs = require("fs");
 
-const { dependencies, peerDependencies } = require("../package.json");
+const { dependencies, peerDependencies, version } = require("../package.json");
 
 const opts = {
     entryPoints: ["src/index.ts"],
@@ -25,6 +26,9 @@ try {
         platform: "node",
         outfile: "dist/umd/react-oidc-context.js",
     });
+    // generate package.json for esm
+    const distPackageJson = { type: "module" , version };
+    fs.writeFileSync("dist/esm/package.json", JSON.stringify(distPackageJson, null, 2) + "\n");
 } catch (err) {
     // esbuild handles error reporting
     process.exitCode = 1;


### PR DESCRIPTION
## Description
This pull request addresses a warning emitted by webpack that occurs when building the project. The warning indicates the absence of a version specification in the `package.json` of the `dist/esm` directory. To rectify this, I have implemented a solution to automatically copy the version from the main `package.json` to the `dist/esm/package.json` upon each successful build. This resolves the warning and ensures that the version information is consistently propagated to the built package.

<img width="1405" alt="image" src="https://github.com/authts/react-oidc-context/assets/44866256/adfa9567-3285-4e7f-96e9-59012eb768d3">

## Changes Made

- Implemented an automatic version copying script from `package.json` to `dist/esm/package.json` after every build.
- Modified the existing build script to incorporate the new version copying functionality.

## How to Test

1. Run the build process using the provided build script.
2. Verify that the version in `package.json` matches the version in `dist/esm/package.json`.
3. Confirm that the webpack warning related to the missing version is no longer present.

## Related Issues
Closes/fixes #690 

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
