### PR TITLE
backport handle USER_SIGNED_OUT event the same like USER_UNLOADED

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -281,6 +281,12 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         };
         userManager.events.addUserUnloaded(handleUserUnloaded);
 
+        // event UserSignedOut (e.g. user was signed out in background (checkSessionIFrame option))
+        const handleUserSignedOut = () => {
+            dispatch({ type: "USER_SIGNED_OUT" });
+        };
+        userManager.events.addUserSignedOut(handleUserSignedOut);
+
         // event SilentRenewError (silent renew error)
         const handleSilentRenewError = (error: Error) => {
             dispatch({ type: "ERROR", error });
@@ -290,6 +296,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         return () => {
             userManager.events.removeUserLoaded(handleUserLoaded);
             userManager.events.removeUserUnloaded(handleUserUnloaded);
+            userManager.events.removeUserSignedOut(handleUserSignedOut);
             userManager.events.removeSilentRenewError(handleSilentRenewError);
         };
     }, [userManager]);

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -5,6 +5,7 @@ import type { AuthState } from "./AuthState";
 type Action =
     | { type: "INITIALISED" | "USER_LOADED"; user: User | null }
     | { type: "USER_UNLOADED" }
+    | { type: "USER_SIGNED_OUT" }
     | { type: "NAVIGATOR_INIT"; method: NonNullable<AuthState["activeNavigator"]> }
     | { type: "NAVIGATOR_CLOSE" }
     | { type: "ERROR"; error: Error };
@@ -23,6 +24,7 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
                 isAuthenticated: action.user ? !action.user.expired : false,
                 error: undefined,
             };
+        case "USER_SIGNED_OUT":
         case "USER_UNLOADED":
             return {
                 ...state,


### PR DESCRIPTION
backport #1087: handle USER_SIGNED_OUT (session monitoring event) event the same like USER_UNLOADED

(cherry picked from commit fa99ee20d8cd7f87c90523626960359387672450)

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
