### PR TITLE
new JSX transform needs at least React v16.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "oidc-client-ts": "^3.1.0",
-    "react": ">=16.8.0"
+    "react": ">=16.14.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.48.0",


### PR DESCRIPTION
See https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
