### PR TITLE
test: fix the "ts-jest" config option "isolatedModules" is deprecated…

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,13 +12,4 @@ export default {
     },
     collectCoverage,
     coverageReporters: collectCoverage ? ["lcov"] : ["lcov", "text"],
-    transform: {
-        "^.+\\.tsx?$": [
-            "ts-jest",
-            {
-                // skip ts-jest type checking, incremental compilation with tsc is much faster
-                isolatedModules: true,
-            },
-        ],
-    },
 };


### PR DESCRIPTION
… and will be removed in v30.0.0. Please use "isolatedModules: true"

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
