### PR TITLE
make use of trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write # Required for pushing docs
+  id-token: write # Required for provenance
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,11 +26,7 @@ jobs:
       - name: Publish package release
         if: "!github.event.release.prerelease"
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish package pre-release
         if: "github.event.release.prerelease"
         run: npm publish --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Trusted publishing allows you to publish npm packages directly from your CI/CD workflows using [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) authentication, eliminating the need for long-lived npm tokens.
- https://docs.npmjs.com/trusted-publishers#limitations-and-future-improvements

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
