### PR TITLE
docs(readme): use ref instead of state for sign in try

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,18 +286,18 @@ import { useAuth, hasAuthParams } from "react-oidc-context";
 
 function App() {
     const auth = useAuth();
-    const [hasTriedSignin, setHasTriedSignin] = React.useState(false);
+    const hasTriedSignin = React.useRef(false);
 
     // automatically sign-in
     React.useEffect(() => {
         if (!hasAuthParams() &&
             !auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading &&
-            !hasTriedSignin
+            !hasTriedSignin.current
         ) {
             auth.signinRedirect();
-            setHasTriedSignin(true);
+            hasTriedSignin.current = true;
         }
-    }, [auth, hasTriedSignin]);
+    }, [auth]);
 
     if (auth.isLoading) {
         return <div>Signing you in/out...</div>;


### PR DESCRIPTION
`eslint-plugin-react-hooks` v7 warns that "Calling setState synchronously within an effect can trigger cascading renders".

Resolves #1835

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
