### PR TITLE
[Fix] typo on error field

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ function App() {
     }
 
     if (auth.error) {
-        return <div>Oops... {auth.error.kind} caused {auth.error.message}</div>;
+        return <div>Oops... {auth.error.source} caused {auth.error.message}</div>;
     }
 
     if (auth.isAuthenticated) {


### PR DESCRIPTION
Original PR use `.source` on the error context:

https://github.com/authts/react-oidc-context/commit/64a50733f16308cf387181c4db31c39d49c40c7f

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/react-oidc-context.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
